### PR TITLE
add `allowedHosts` in `vite.config.js`

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,6 +4,7 @@ import {defineConfig} from 'vite';
 export default defineConfig({
   envDir: '../',
   server: {
+    allowedHosts: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',


### PR DESCRIPTION
when cloning the repo and following the tutorial steps, we run into a `Blocked request` page informing us to allow the host.

<img width="1926" height="646" alt="image" src="https://github.com/user-attachments/assets/49736e32-e220-4c6f-b153-b3b9f1705604" />

when including the `allowedHosts: true` we are then able to access the activity with no issues in discord.

<img width="1806" height="1226" alt="image" src="https://github.com/user-attachments/assets/d22957d4-f5d1-4826-843c-8add6d1aaad5" />

this PR just adds the missing config `allowedHosts: true` for a better tutorial experience.