### PR TITLE
fix: server error handling, package name typo, and docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Activity: Getting Started Guide
 
-This template is used in the [Building An Activity](https://discord.com/developers/docs/activities/building-an-activity) tutorial in the Discord Developer Docs.
+This template is used in the [Building An Activity](https://docs.discord.com/developers/activities/building-an-activity) tutorial in the Discord Developer Docs.
 
-Read more about building Discord Activities with the Embedded App SDK at [https://discord.com/developers/docs/activities/overview](https://discord.com/developers/docs/activities/overview).
+Read more about building Discord Activities with the Embedded App SDK at [https://docs.discord.com/developers/activities/overview](https://docs.discord.com/developers/activities/overview).
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "getting-starter-activity-server",
+  "name": "getting-started-activity-server",
   "version": "1.0.0",
   "description": "",
   "main": "server.js",

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,12 @@ const port = 3001;
 app.use(express.json());
 
 app.post("/api/token", async (req, res) => {
-  
+  const code = req.body.code;
+
+  if (!code) {
+    return res.status(400).send({ error: "Missing authorization code" });
+  }
+
   // Exchange the code for an access_token
   const response = await fetch(`https://discord.com/api/oauth2/token`, {
     method: "POST",
@@ -21,15 +26,19 @@ app.post("/api/token", async (req, res) => {
       client_id: process.env.VITE_DISCORD_CLIENT_ID,
       client_secret: process.env.DISCORD_CLIENT_SECRET,
       grant_type: "authorization_code",
-      code: req.body.code,
+      code,
     }),
   });
 
   // Retrieve the access_token from the response
-  const { access_token } = await response.json();
+  const data = await response.json();
+
+  if (!response.ok || !data.access_token) {
+    return res.status(response.status).send({ error: data.error ?? "Token exchange failed" });
+  }
 
   // Return the access_token to our client as { access_token: "..."}
-  res.send({access_token});
+  res.send({ access_token: data.access_token });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary

3 fixes for the getting started activity template.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `server/server.js` | No input validation or error handling on `/api/token` — returns `{access_token: undefined}` when Discord API returns an error | Added code validation, response status check, and error propagation |
| `server/package.json` | Package name typo: `getting-starter-activity-server` | Fixed to `getting-started-activity-server` |
| `README.md` | Docs URLs use old format (`discord.com/developers/docs/`) | Updated to new `docs.discord.com/developers/` format |

## Details

The token exchange endpoint had no error handling — if Discord returned a 400/401 (expired code, wrong secret, etc.), the server would destructure `access_token` from the error response body and send `{access_token: undefined}` back to the client with a 200 status, making it impossible to diagnose auth failures.